### PR TITLE
AGDR-552

### DIFF
--- a/docs/release_notes/2024_10_10.md
+++ b/docs/release_notes/2024_10_10.md
@@ -1,0 +1,50 @@
+---
+title: 10 October 2024
+description: "AGDR release notes for 10 October 2024"
+---
+
+Versions:
+
+`Dictionary: 2024_09_10`
+
+`Submission (sheepdog): v2023.06`
+
+`Portal: Production-6.8`
+
+Internal:
+
+`indexd: 2023.06`
+
+`fence: 2022.05`
+
+`arborist: 2023.06`
+
+`peregrine: 2023.06`
+
+`sheepdog: 2023.6`
+
+`guppy: 2023.06`
+
+`elastic search: oss:6.8.21`
+
+`pidgin: 2023.06`
+
+`nginx: 2023.06 (from quay.io/cdis/nginx)`
+
+`tube: 2022.05`
+
+`gen3-spark: 2023.06`
+
+`NeSI metadata service: v6.0`
+
+`postgres 15.2.0-debian-11-r21`
+
+Note: JupyterHub, Kibana are not used and not updated
+
+## New and Improved
+
+N/A  
+
+## Fixes
+
+- /study-viewer pages are now redirected to the project pages /discovery.  


### PR DESCRIPTION
- /study-viewer pages are now redirected to the project pages /discovery.  