### PR TITLE
Update 2026_05_29.md

### DIFF
--- a/docs/release_notes/2026_05_29.md
+++ b/docs/release_notes/2026_05_29.md
@@ -8,7 +8,7 @@ description: "AGDR release notes for 29 May 2026"
 - Dictionary: 2025_09_01
 - Submission (sheepdog): v2026.02
 - Portal: production-7.2.4-2026.02
-- AGDR Internal helm chart: 1.4-0.2.13
+- AGDR Internal helm chart: 1.5-0.2.13
 - REMS: 1.0
 
 


### PR DESCRIPTION
typo in internal-helm-chart version was listed as 1.4 but should be 1.5